### PR TITLE
[definition provider] tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Form, data behaviours",
   "main": "src/index.js",
   "scripts": {
-    "test": "mocha src/**/__tests__/**/*.js",
-    "test:watch": "mocha src/**/__tests__/**/*.js --watch",
+    "test": "BABEL_ENV=test mocha src/**/__tests__/**/*.js",
+    "test:watch": "BABEL_ENV=test mocha src/**/__tests__/**/*.js --watch",
     "start": "better-npm-run dev-server"
   },
   "betterScripts": {

--- a/src/actions/__tests__/entity-action-builder-test.js
+++ b/src/actions/__tests__/entity-action-builder-test.js
@@ -44,20 +44,20 @@ describe('The actionBuilder', () => {
         const TEST_VALID_ACTION_BUILDER_PARAMS_REJECT = {name: 'test', type: 'load', service: ()=> Promise.reject(REJECT_VALUE)};
         it('should return an object with types, creators, action', () => {
             const actionBuilded = actionBuilder(TEST_VALID_ACTION_BUILDER_PARAMS_RESOLVE);
-            expect(actionBuilded).to.be.an.object;
+            expect(actionBuilded).to.be.an('object');
             expect(actionBuilded).to.include.keys('types', 'creators', 'action');
         });
         describe('The types part of the result', () => {
           it('should return an object with three types with REQUEST, RECEIVE and ERROR', () => {
               const {types: actionBuildedTypes} = actionBuilder(TEST_VALID_ACTION_BUILDER_PARAMS_RESOLVE);
-              expect(actionBuildedTypes).to.be.an.object;
+              expect(actionBuildedTypes).to.be.an('object');
               expect(actionBuildedTypes).to.include.keys('REQUEST_LOAD_TEST', 'RECEIVE_LOAD_TEST', 'ERROR_LOAD_TEST');
           });
         });
         describe('The creators part of the result', () => {
           const {creators: actionBuildedCreators} = actionBuilder(TEST_VALID_ACTION_BUILDER_PARAMS_RESOLVE);
           it('should return an object with three keys with request, receive, error', () => {
-              expect(actionBuildedCreators).to.be.an.object;
+              expect(actionBuildedCreators).to.be.an('object');
               expect(actionBuildedCreators).to.include.keys('requestLoadTest', 'receiveLoadTest', 'errorLoadTest');
           });
           it('should return an object with three values with request, receive, error', () => {

--- a/src/behaviours/__tests__/definition-test.js
+++ b/src/behaviours/__tests__/definition-test.js
@@ -21,40 +21,24 @@ describe('Definition behaviour', () => {
          expect(component.type).to.be.equal(TestComponent);
        });
        it('should throw an error when there are no props', ()=>{
-         expect(()=>{
-           _tryRenderProviderWithProps();
-         }).to.throw(PROVIDER_VALIDATION_MSG)
+         expect(() => _tryRenderProviderWithProps()).to.throw(PROVIDER_VALIDATION_MSG)
        })
        it('should throw an error when props is an empty object', ()=>{
-         expect(()=>{
-           _tryRenderProviderWithProps({});
-         }).to.throw(PROVIDER_VALIDATION_MSG)
+         expect(() => _tryRenderProviderWithProps({})).to.throw(PROVIDER_VALIDATION_MSG)
        })
        it('should throw an error when  definitions is a number', ()=>{
-         expect(()=>{
-           _tryRenderProviderWithProps({definitions: 1});
-         }).to.throw(PROVIDER_VALIDATION_MSG)
+         expect(() => _tryRenderProviderWithProps({definitions: 1})).to.throw(PROVIDER_VALIDATION_MSG)
        })
        it('should throw an error when  definitions is a string', ()=>{
-         expect(()=>{
-           _tryRenderProviderWithProps({definitions: "a"});
-         }).to.throw(PROVIDER_VALIDATION_MSG)
-       })
+         expect(() => _tryRenderProviderWithProps({definitions: 'a'})).to.throw(PROVIDER_VALIDATION_MSG)
+       });
        it('should throw an error when definitions is an array', ()=>{
-         expect(()=>{
-           _tryRenderProviderWithProps({definitions: []});
-         }).to.throw(PROVIDER_VALIDATION_MSG)
-       })
-
+         expect(() => _tryRenderProviderWithProps({definitions: []})).to.throw(PROVIDER_VALIDATION_MSG)
+       });
        it('should throw an error when definitions is a function', ()=>{
-         expect(()=>{
-           _tryRenderProviderWithProps({definitions: ()=>{}});
-         }).to.throw(PROVIDER_VALIDATION_MSG)
+         expect(() => _tryRenderProviderWithProps({definitions: ()=>{}})).to.throw(PROVIDER_VALIDATION_MSG)
        })
        it('should throw an error when definitions is an empty object', ()=>{
-         expect(()=>{
-           _tryRenderProviderWithProps({definitions: {}});
-         }).to.throw(PROVIDER_VALIDATION_MSG)
+         expect(() => _tryRenderProviderWithProps({definitions: {}})).to.throw(PROVIDER_VALIDATION_MSG)
        })
-
 })});

--- a/src/behaviours/__tests__/definition-test.js
+++ b/src/behaviours/__tests__/definition-test.js
@@ -12,7 +12,7 @@ describe('Definition behaviour', () => {
           return shallowRenderer.getRenderOutput();
        };
        it('should be a class', () => {
-          expect(Provider).to.be.a.function;
+          expect(Provider).to.be.a('function');
         });
        it('should be a react component with childContextTypes', () => {
          expect(Provider.childContextTypes).to.deep.equal({
@@ -20,7 +20,7 @@ describe('Definition behaviour', () => {
          })
        });
        it('should be a class with getChildContext method', () => {
-         expect(Provider.getChildContext).to.be.a.function;
+         expect(Provider.prototype.getChildContext).to.be.a('function');
        });
        it('should render a React component', () => {
          component = _tryRenderProviderWithProps({definitions:{test: {name: 'test'}}});
@@ -53,10 +53,10 @@ describe('Definition behaviour', () => {
     describe('the connect function', () => {
       const CONNECTOR_VALIDATION_MESSAGE = 'BEHAVIOUR_DEFINITION_CONNECT:  The definition name should be s string or an array of strings.';
       it('shoud be a function', () => {
-        expect(connect).to.be.a.function;
+        expect(connect).to.be.a('function');
       });
       it('shoud accept a string parameter and return a connector', () => {
-        expect(connect('n1')).to.be.a.function;
+        expect(connect('n1')).to.be.a('function');
       });
       it('shoud not accept a number parameter', () => {
         expect(()=> connect(1)).to.throw(CONNECTOR_VALIDATION_MESSAGE);
@@ -71,18 +71,42 @@ describe('Definition behaviour', () => {
         expect(()=> connect([])).to.throw(CONNECTOR_VALIDATION_MESSAGE);
       });
       it('shoud accept an array of string parameter and return a connector', () => {
-        expect(connect(['n1', 'n2'])).to.be.a.function;
+        expect(connect(['n1', 'n2'])).to.be.a('function');
       });
     });
     describe('the connectComponentToDefinitions function', () => {
-      const DEFINITIONS = {n1: {f1:{domain: 'DO_LOPEZ'}, f2:{domain: 'DO_JOE'}}, n2: {f1:{domain: 'DO_DAVID'}, f2:{domain: 'DO_DIEGO'}}}
-      const _tryRenderInAProvider = toRender => {
+      const TestComponent = props => JSON.stringify(props);
+      TestComponent.displayName = 'TestComponent';
+      const _tryRenderWithDefinitionContext = (toRender, context) => {
         const shallowRenderer = TestUtils.createRenderer();
-        shallowRenderer.render(<Provider definitions={DEFINITIONS}>{toRender()}</Provider>);
-          return shallowRenderer.getRenderOutput();
+        shallowRenderer.render(toRender(), context);
+        return shallowRenderer.getRenderOutput();
        };
-      it('shoud accept a string parameter', () => {
-        expect(_tryRenderInAProvider(() => connect('n1')(props => <div>test</div>))).to.be.a.function;
+      it('shoud return a react component', () => {
+       const ConnectedTestComponent = connect('n1')(TestComponent);
+       expect(ConnectedTestComponent).to.be.a('function');
+      });
+      describe('render with a correct definitionContext', () => {
+        const DEFINITIONS = {n1: {f1:{domain: 'DO_LOPEZ'}, f2:{domain: 'DO_JOE'}}, n2: {f1:{domain: 'DO_DAVID'}, f2:{domain: 'DO_DIEGO'}}}
+        const ConnectedTestComponent = connect('n1')(TestComponent);
+        const component = _tryRenderWithDefinitionContext(() =>  <ConnectedTestComponent/>, {definitions: DEFINITIONS});
+        it('shoud render a component', () => {
+          expect(component).to.be.a('object');
+        });
+        it('shoud render a component with props', () => {
+          expect(component.props).to.be.a('object');
+        });
+        it('should have the _behaviours{isConnectedToDefinition} as props', () => {
+          const {_behaviours} = component.props;
+          expect(_behaviours).to.be.a('object');
+          expect(_behaviours.isConnectedToDefinition).to.be.a('boolean');
+          expect(_behaviours.isConnectedToDefinition).to.be.equal(true);
+        })
+        it('should have the definition as props', () => {
+          const {definition} = component.props;
+          expect(definition).to.be.a('object');
+          expect(definition).to.be.deep.equal(DEFINITIONS.n1);
+        });
       });
     });
   });

--- a/src/behaviours/__tests__/definition-test.js
+++ b/src/behaviours/__tests__/definition-test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import {connect, Provider} from '../definitions';
+
+describe('Definition behaviour', () => {
+    describe('The provider', () => {
+      let component;
+      const TestComponent = (props, context) => <div id='testContent'>{JSON.stringify(context)}</div>;
+      const PROVIDER_VALIDATION_MSG = 'BEHAVIOUR_DEFINITION_PROVIDER the provider needs a definitions props which should be a non empty object';
+      const _tryRenderProviderWithProps = props => {
+        const shallowRenderer = TestUtils.createRenderer();
+        shallowRenderer.render(
+          <Provider {...props}>
+          <TestComponent />
+          </Provider>
+        );
+          return shallowRenderer.getRenderOutput();
+      };
+       it('should render a React component', () => {
+         component = _tryRenderProviderWithProps({definitions:{test: {name: 'test'}}});
+         expect(component).to.be.an('object');
+         expect(component.type).to.be.equal(TestComponent);
+       });
+       it('should throw an error when there are no props', ()=>{
+         expect(()=>{
+           _tryRenderProviderWithProps();
+         }).to.throw(PROVIDER_VALIDATION_MSG)
+       })
+       it('should throw an error when props is an empty object', ()=>{
+         expect(()=>{
+           _tryRenderProviderWithProps({});
+         }).to.throw(PROVIDER_VALIDATION_MSG)
+       })
+       it('should throw an error when  definitions is a number', ()=>{
+         expect(()=>{
+           _tryRenderProviderWithProps({definitions: 1});
+         }).to.throw(PROVIDER_VALIDATION_MSG)
+       })
+       it('should throw an error when  definitions is a string', ()=>{
+         expect(()=>{
+           _tryRenderProviderWithProps({definitions: "a"});
+         }).to.throw(PROVIDER_VALIDATION_MSG)
+       })
+       it('should throw an error when definitions is an array', ()=>{
+         expect(()=>{
+           _tryRenderProviderWithProps({definitions: []});
+         }).to.throw(PROVIDER_VALIDATION_MSG)
+       })
+
+       it('should throw an error when definitions is a function', ()=>{
+         expect(()=>{
+           _tryRenderProviderWithProps({definitions: ()=>{}});
+         }).to.throw(PROVIDER_VALIDATION_MSG)
+       })
+       it('should throw an error when definitions is an empty object', ()=>{
+         expect(()=>{
+           _tryRenderProviderWithProps({definitions: {}});
+         }).to.throw(PROVIDER_VALIDATION_MSG)
+       })
+
+})});

--- a/src/behaviours/__tests__/definition-test.js
+++ b/src/behaviours/__tests__/definition-test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PropTypes} from 'react';
 import {connect, Provider} from '../definitions';
 
 describe('Definition behaviour', () => {
@@ -15,6 +15,17 @@ describe('Definition behaviour', () => {
         );
           return shallowRenderer.getRenderOutput();
       };
+       it('should be a class', () => {
+          expect(Provider).to.be.a.function;
+       });
+       it('should be a react component with childContextTypes', () => {
+         expect(Provider.childContextTypes).to.deep.equal({
+           definitions: PropTypes.object
+         })
+       });
+       it('should be a class with getChildContext method', () => {
+         expect(Provider.getChildContext).to.be.a.function;
+       });
        it('should render a React component', () => {
          component = _tryRenderProviderWithProps({definitions:{test: {name: 'test'}}});
          expect(component).to.be.an('object');
@@ -41,4 +52,5 @@ describe('Definition behaviour', () => {
        it('should throw an error when definitions is an empty object', ()=>{
          expect(() => _tryRenderProviderWithProps({definitions: {}})).to.throw(PROVIDER_VALIDATION_MSG)
        })
-})});
+  })
+});

--- a/src/behaviours/__tests__/definition-test.js
+++ b/src/behaviours/__tests__/definition-test.js
@@ -75,16 +75,41 @@ describe('Definition behaviour', () => {
       });
     });
     describe('the connectComponentToDefinitions function', () => {
-      const TestComponent = props => JSON.stringify(props);
+      const TestComponent = props => <pre><code>{JSON.stringify(props)}</code></pre>;
       TestComponent.displayName = 'TestComponent';
       const _tryRenderWithDefinitionContext = (toRender, context) => {
         const shallowRenderer = TestUtils.createRenderer();
         shallowRenderer.render(toRender(), context);
         return shallowRenderer.getRenderOutput();
        };
+       const NO_DEF_MSG = 'BEHAVIOUR_DEFINITION_CONNECT The definitions must be an object check your **DefinitionsProvider**';
       it('shoud return a react component', () => {
        const ConnectedTestComponent = connect('n1')(TestComponent);
        expect(ConnectedTestComponent).to.be.a('function');
+      });
+      describe('when rendered with a wrong context', () => {
+        it('should throw an error when there is no context', () => {
+          const ConnectedTestComponent = connect('n1')(TestComponent);
+          expect(
+            () => _tryRenderWithDefinitionContext(
+              () => <ConnectedTestComponent />,
+              null
+            )
+          ).to.throw(NO_DEF_MSG)
+        })
+        it('should throw an error when there are no definitions', () => {
+          expect(()=> _tryRenderWithDefinitionContext(() => <ConnectedTestComponent />, {})).to.throw('ConnectedTestComponent is not defined')
+        })
+        it('should throw an error when the requested definition is not present', () => {
+          const WRONG_DEF_MSG = 'BEHAVIOUR_DEFINITION_CONNECT The definition you requested : nimp does not exists or is not an object, check your **DefinitionsProvider**';
+          const ConnectedTestComponent = connect('nimp')(TestComponent);
+          expect(
+            () => _tryRenderWithDefinitionContext(
+              () => <ConnectedTestComponent />,
+              {definitions: {n1: {domain: 'PAPA'}}}
+            )
+          ).to.throw(WRONG_DEF_MSG);
+        })
       });
       describe('render with a correct definitionContext', () => {
         const DEFINITIONS = {n1: {f1:{domain: 'DO_LOPEZ'}, f2:{domain: 'DO_JOE'}}, n2: {f1:{domain: 'DO_DAVID'}, f2:{domain: 'DO_DIEGO'}}}

--- a/src/behaviours/__tests__/definition-test.js
+++ b/src/behaviours/__tests__/definition-test.js
@@ -2,22 +2,18 @@ import React, {PropTypes} from 'react';
 import {connect, Provider} from '../definitions';
 
 describe('Definition behaviour', () => {
-    describe('The provider', () => {
+    describe('The definitions provider', () => {
       let component;
       const TestComponent = (props, context) => <div id='testContent'>{JSON.stringify(context)}</div>;
       const PROVIDER_VALIDATION_MSG = 'BEHAVIOUR_DEFINITION_PROVIDER the provider needs a definitions props which should be a non empty object';
       const _tryRenderProviderWithProps = props => {
         const shallowRenderer = TestUtils.createRenderer();
-        shallowRenderer.render(
-          <Provider {...props}>
-          <TestComponent />
-          </Provider>
-        );
+        shallowRenderer.render(<Provider {...props}><TestComponent /></Provider>);
           return shallowRenderer.getRenderOutput();
-      };
+       };
        it('should be a class', () => {
           expect(Provider).to.be.a.function;
-       });
+        });
        it('should be a react component with childContextTypes', () => {
          expect(Provider.childContextTypes).to.deep.equal({
            definitions: PropTypes.object
@@ -52,5 +48,42 @@ describe('Definition behaviour', () => {
        it('should throw an error when definitions is an empty object', ()=>{
          expect(() => _tryRenderProviderWithProps({definitions: {}})).to.throw(PROVIDER_VALIDATION_MSG)
        })
-  })
+  });
+  describe('The connect to definitions', () => {
+    describe('the connect function', () => {
+      const CONNECTOR_VALIDATION_MESSAGE = 'BEHAVIOUR_DEFINITION_CONNECT:  The definition name should be s string or an array of strings.';
+      it('shoud be a function', () => {
+        expect(connect).to.be.a.function;
+      });
+      it('shoud accept a string parameter and return a connector', () => {
+        expect(connect('n1')).to.be.a.function;
+      });
+      it('shoud not accept a number parameter', () => {
+        expect(()=> connect(1)).to.throw(CONNECTOR_VALIDATION_MESSAGE);
+      });
+      it('shoud not accept a number parameter', () => {
+        expect(()=> connect(()=>{})).to.throw(CONNECTOR_VALIDATION_MESSAGE);
+      });
+      it('shoud not accept an empty string parameter', () => {
+        expect(()=> connect('')).to.throw(CONNECTOR_VALIDATION_MESSAGE);
+      });
+      it('shoud not accept an empty array parameter', () => {
+        expect(()=> connect([])).to.throw(CONNECTOR_VALIDATION_MESSAGE);
+      });
+      it('shoud accept an array of string parameter and return a connector', () => {
+        expect(connect(['n1', 'n2'])).to.be.a.function;
+      });
+    });
+    describe('the connectComponentToDefinitions function', () => {
+      const DEFINITIONS = {n1: {f1:{domain: 'DO_LOPEZ'}, f2:{domain: 'DO_JOE'}}, n2: {f1:{domain: 'DO_DAVID'}, f2:{domain: 'DO_DIEGO'}}}
+      const _tryRenderInAProvider = toRender => {
+        const shallowRenderer = TestUtils.createRenderer();
+        shallowRenderer.render(<Provider definitions={DEFINITIONS}>{toRender()}</Provider>);
+          return shallowRenderer.getRenderOutput();
+       };
+      it('shoud accept a string parameter', () => {
+        expect(_tryRenderInAProvider(() => connect('n1')(props => <div>test</div>))).to.be.a.function;
+      });
+    });
+  });
 });

--- a/src/behaviours/definitions.js
+++ b/src/behaviours/definitions.js
@@ -19,8 +19,18 @@ export function connect(definitionName){
   }
 
   return function connectComponentToDefinitions(ComponentToConnect){
-    function DefinitionConnectedComponent(props, {definitions}){
+    function DefinitionConnectedComponent(props, context){
+        if(!isObject(context)){
+          throw new Error(`${BEHAVIOUR_DEFINITION_CONNECT} The context must be an object check your **DefinitionsProvider**`)
+        }
+        const {definitions} = context;
+        if(!isObject(definitions)){
+          throw new Error(`${BEHAVIOUR_DEFINITION_CONNECT} The definitions must be an object check your **DefinitionsProvider**`)
+        }
         const definition = definitions[definitionName];
+        if(!isObject(definition)){
+          throw new Error(`${BEHAVIOUR_DEFINITION_CONNECT} The definition you requested : ${definitionName} does not exists or is not an object, check your **DefinitionsProvider**`)
+        }
         const {_behaviours, ...otherProps} = props;
         const behaviours = {isConnectedToDefinition: true,..._behaviours}
         //console.log('def', definition, "props", props);

--- a/src/behaviours/definitions.js
+++ b/src/behaviours/definitions.js
@@ -1,8 +1,18 @@
 import React , {Component, PropTypes} from 'react';
+import {isEmpty, isObject, isFunction} from 'lodash/lang';
+
+
+const BEHAVIOUR_DEFINITION_PROVIDER = 'BEHAVIOUR_DEFINITION_PROVIDER';
+const BEHAVIOUR_DEFINITION_CONNECT = 'BEHAVIOUR_DEFINITION_CONNECT';
+//Mutualization of the context type
 const DEFINITION_CONTEXT_TYPE = {
   definitions: PropTypes.object
 };
 
+// The function uses a Higher Order Component pattern to provide
+//
+//
+//
 export function connect(definitionName){
   //console.log('definition ');
   //check it is a string or an array;
@@ -19,7 +29,17 @@ export function connect(definitionName){
 
 }
 
+
 class DefinitionsProvider extends Component {
+  constructor(props){
+    super(props);
+    this._validatePropsDefinitions(props);
+  }
+  _validatePropsDefinitions(props){
+    if(!isObject(props.definitions) || isFunction(props.definitions) || isEmpty(props.definitions)){
+      throw new Error(`${BEHAVIOUR_DEFINITION_PROVIDER} the provider needs a definitions props which should be a non empty object`);
+    }
+  }
   getChildContext(){
     return {
       definitions: this.props.definitions

--- a/src/behaviours/definitions.js
+++ b/src/behaviours/definitions.js
@@ -17,13 +17,14 @@ export function connect(definitionName){
   if(!((isString(definitionName) || isArray(definitionName)) && definitionName.length) > 0){
     throw new Error(`${BEHAVIOUR_DEFINITION_CONNECT}:  The definition name should be s string or an array of strings.`)
   }
-  //console.log('definition ');
-  //check it is a string or an array;
+
   return function connectComponentToDefinitions(ComponentToConnect){
     function DefinitionConnectedComponent(props, {definitions}){
         const definition = definitions[definitionName];
+        const {_behaviours, ...otherProps} = props;
+        const behaviours = {isConnectedToDefinition: true,..._behaviours}
         //console.log('def', definition, "props", props);
-        return <ComponentToConnect hasConnectedToDefinition={true} definition={definition} {...props} />;
+        return <ComponentToConnect _behaviours={behaviours} definition={definition} {...otherProps} />;
     }
     DefinitionConnectedComponent.displayName = `${ComponentToConnect.displayName}DefinitionConnected`;
     DefinitionConnectedComponent.contextTypes = DEFINITION_CONTEXT_TYPE;
@@ -37,6 +38,7 @@ class DefinitionsProvider extends Component {
   constructor(props){
     super(props);
     this._validatePropsDefinitions(props);
+    //console.log(props);
   }
   _validatePropsDefinitions(props){
     if(!isObject(props.definitions) || isFunction(props.definitions) || isEmpty(props.definitions)){

--- a/src/behaviours/definitions.js
+++ b/src/behaviours/definitions.js
@@ -1,5 +1,5 @@
 import React , {Component, PropTypes} from 'react';
-import {isEmpty, isObject, isFunction} from 'lodash/lang';
+import {isEmpty, isObject, isFunction, isString, isArray} from 'lodash/lang';
 
 
 const BEHAVIOUR_DEFINITION_PROVIDER = 'BEHAVIOUR_DEFINITION_PROVIDER';
@@ -14,6 +14,9 @@ const DEFINITION_CONTEXT_TYPE = {
 //
 //
 export function connect(definitionName){
+  if(!((isString(definitionName) || isArray(definitionName)) && definitionName.length) > 0){
+    throw new Error(`${BEHAVIOUR_DEFINITION_CONNECT}:  The definition name should be s string or an array of strings.`)
+  }
   //console.log('definition ');
   //check it is a string or an array;
   return function connectComponentToDefinitions(ComponentToConnect){


### PR DESCRIPTION
- Definition
  - [x] Add tests for the provider
  - [x] Add test for the connector 

## Doc

###  Add a convention for all behaviours
When a component has a behaviour, which is a decorator, the `focus` decorator will add a boolean in a special props: `_behaviours`
This way it is easy to track in the `React` devTools which enhancers are used with your component.
Also we might create a DX tool to help with this.
```jsx
const ConnectedComponent = connect(MyComponent);
ReactDOM.render(<ConnectedComponent/>, document.querySelector('#container'))
// the connectedComponent will have a _behaviours={isConnectedToDefinition: true}
```

## Todo: (next PR)
- Field Helpers
  - [ ] Add tests for the provider
  - [ ] Add test for the connector
- Smart data
  - [ ] Add tests for the provider
  - [ ] Add test for the connector