### PR TITLE
Feature master data

### DIFF
--- a/src/actions/__tests__/master-data-test.js
+++ b/src/actions/__tests__/master-data-test.js
@@ -1,10 +1,13 @@
-import {loadMasterData} from '../master-data';
+import {loadMasterData, REQUEST_MASTER_DATA, RESPONSE_MASTER_DATA, ERROR_MASTER_DATA} from '../master-data';
 const NAME_SHOULD_BE_A_STRING = 'LOAD_MASTER_DATA_ACTION: the name parameter should be a string.';
 const SERVICE_SHOULD_BE_A_FUNCTION = 'LOAD_MASTER_DATA_ACTION: the service parameter should be a function.';
 const CACHE_DURATION_SHOULD_BE_A_NUMBER = 'LOAD_MASTER_DATA_ACTION: the cacheDuration parameter should be a number.';
 
 const MOCKED_MASTER_DATA = [{code: 1, value: 'Un'}, {code: 2, value: 'Deux'}];
-const MOCKED_SVC = () => Promise.resolve(MOCKED_MASTER_DATA);
+const MOCKED_SVC = () => {
+            console.log('PROM');
+  return Promise.resolve(MOCKED_MASTER_DATA)
+};
 
 describe('master data actions', () => {
   describe.only('loadMasterData', () => {
@@ -66,30 +69,57 @@ describe('master data actions', () => {
           });
 
         });
+        describe('The builded action part of the result', () => {
+            const NAME = 'chiffres';
+            const ERROR_MASTER_DATA_MOCK = 'No way to load this list';
+            const loadActionWithResolveServiceAsync =  loadMasterData(NAME, d => Promise.resolve(MOCKED_MASTER_DATA), 0);
+            const loadActionWithResolveServiceAsyncWithCache =  loadMasterData(NAME, d => Promise.resolve(MOCKED_MASTER_DATA));
+            const loadActionWithRejectServiceAsync =  loadMasterData(NAME, d => Promise.reject(ERROR_MASTER_DATA_MOCK), 0);
 
-/*        it('should throw an error when called without a string name parameter', () => {
-            const NAME_MESSAGE = 'ACTION_BUILDER: the name parameter should be a string.';
-            expect(() => { loadMasterData({name: undefined})}).to.throw(NAME_MESSAGE);
-            expect(() => { loadMasterData({name: 1})}).to.throw(NAME_MESSAGE);
-            expect(() => { loadMasterData({name: {}})}).to.throw(NAME_MESSAGE);
-            expect(() => { loadMasterData({name: () => {}})}).to.throw(NAME_MESSAGE);
-            expect(() => { loadMasterData({name: ''})}).to.throw(NAME_MESSAGE);
-            expect(() => { loadMasterData({name: 'test'})}).to.not.throw(NAME_MESSAGE);
+            it('should return a function', () => {
+              expect(loadActionWithResolveServiceAsync).to.be.a.function;
+              expect(loadActionWithResolveServiceAsync).to.be.a.function;
+            });
+
+            it('when called with a successfull service should call the response and request action creators', async done => {
+              const dispatchSpy = sinon.spy();
+              await loadActionWithResolveServiceAsync(dispatchSpy);
+              expect(dispatchSpy).to.have.been.called.twice;
+              expect(dispatchSpy).to.have.callCount(2);
+              expect(dispatchSpy).to.have.been.called.calledWith({type: REQUEST_MASTER_DATA, name: NAME});
+              expect(dispatchSpy).to.have.been.called.calledWith({type: RESPONSE_MASTER_DATA, name: NAME,  value: MOCKED_MASTER_DATA});
+              done();
+            });
+
+            it('when called with an unsuccessfull service should call the error action creator', async done => {
+              const dispatchSpy = sinon.spy();
+              await loadActionWithRejectServiceAsync(dispatchSpy);
+              expect(dispatchSpy).to.have.been.called.twice;
+              expect(dispatchSpy).to.have.callCount(2);
+              expect(dispatchSpy).to.have.been.called.calledWith({type: REQUEST_MASTER_DATA, name: NAME});
+              expect(dispatchSpy).to.have.been.called.calledWith({type: ERROR_MASTER_DATA, name: NAME, error: ERROR_MASTER_DATA_MOCK});
+              done();
+            });
+            it('when called with a successfull service should call the response and request action creators without the cache', async done => {
+              const dispatchSpy = sinon.spy();
+              await loadActionWithResolveServiceAsync(dispatchSpy);
+              await loadActionWithResolveServiceAsync(dispatchSpy);
+              expect(dispatchSpy).to.have.callCount(4);
+              expect(dispatchSpy).to.have.been.called.calledWith({type: REQUEST_MASTER_DATA, name: NAME});
+              expect(dispatchSpy).to.have.been.called.calledWith({type: RESPONSE_MASTER_DATA, name: NAME,  value: MOCKED_MASTER_DATA});
+              done();
+            });
+            it('when called with a successfull service should call the response and request action creators without the cache', async done => {
+              const dispatchSpy = sinon.spy();
+              await loadActionWithResolveServiceAsyncWithCache(dispatchSpy);
+              await loadActionWithResolveServiceAsyncWithCache(dispatchSpy);
+              expect(dispatchSpy).to.have.callCount(2);
+              expect(dispatchSpy).to.have.been.called.calledWith({type: REQUEST_MASTER_DATA, name: NAME});
+              expect(dispatchSpy).to.have.been.called.calledWith({type: RESPONSE_MASTER_DATA, name: NAME,  value: MOCKED_MASTER_DATA});
+              done();
+            });
+
         });
-        it('should throw an error when called without a string type parameter : load,save,delete', () => {
-            const TYPE_MESSAGE = 'ACTION_BUILDER: the type parameter should be a string and the value one of these: load,save,delete.';
-            expect(() => { loadMasterData({name: 'test'})}).to.throw(TYPE_MESSAGE);
-            expect(() => { loadMasterData({name: 'test', type: undefined})}).to.throw(TYPE_MESSAGE);
-            expect(() => { loadMasterData({name: 'test', type: 1})}).to.throw(TYPE_MESSAGE);
-            expect(() => { loadMasterData({name: 'test', type: {}})}).to.throw(TYPE_MESSAGE);
-            expect(() => { loadMasterData({name: 'test', type: () => {}})}).to.throw(TYPE_MESSAGE);
-            expect(() => { loadMasterData({name: 'test', type: ''})}).to.throw(TYPE_MESSAGE);
-            expect(() => { loadMasterData({name: 'test', type: 'nimp'})}).to.throw(TYPE_MESSAGE);
-            expect(() => { loadMasterData({name: 'test', type: 'load'})}).to.not.throw(TYPE_MESSAGE);
-            expect(() => { loadMasterData({name: 'test', type: 'save'})}).to.not.throw(TYPE_MESSAGE);
-            expect(() => { loadMasterData({name: 'test', type: 'delete'})}).to.not.throw(TYPE_MESSAGE);
-        });
-        */
     });
   })
 });

--- a/src/actions/__tests__/master-data-test.js
+++ b/src/actions/__tests__/master-data-test.js
@@ -1,0 +1,95 @@
+import {loadMasterData} from '../master-data';
+const NAME_SHOULD_BE_A_STRING = 'LOAD_MASTER_DATA_ACTION: the name parameter should be a string.';
+const SERVICE_SHOULD_BE_A_FUNCTION = 'LOAD_MASTER_DATA_ACTION: the service parameter should be a function.';
+const CACHE_DURATION_SHOULD_BE_A_NUMBER = 'LOAD_MASTER_DATA_ACTION: the cacheDuration parameter should be a number.';
+
+const MOCKED_MASTER_DATA = [{code: 1, value: 'Un'}, {code: 2, value: 'Deux'}];
+const MOCKED_SVC = () => Promise.resolve(MOCKED_MASTER_DATA);
+
+describe('master data actions', () => {
+  describe.only('loadMasterData', () => {
+    describe('when called with wrong parameters', () => {
+        it('should throw a LOAD_MASTER_DATA_ACTION  on the name error when called without all parameters', () => {
+            expect(() => { loadMasterData()}).to.throw(Error, NAME_SHOULD_BE_A_STRING);
+        });
+        describe('when called with a wrong name parameter', () => {
+
+          it('should throw a name error when called with a number', () => {
+              expect(() => { loadMasterData(1)}).to.throw(Error, NAME_SHOULD_BE_A_STRING);
+          });
+          it('should throw a name error when called with a function', () => {
+              expect(() => { loadMasterData(() => 'test')}).to.throw(Error, NAME_SHOULD_BE_A_STRING);
+          });
+          it('should throw a name error when called with an array', () => {
+              expect(() => { loadMasterData([1,2,3])}).to.throw(Error, NAME_SHOULD_BE_A_STRING);
+          });
+          it('should throw a name error when called with an object', () => {
+              expect(() => { loadMasterData({a: 'a'})}).to.throw(Error, NAME_SHOULD_BE_A_STRING);
+          });
+          it('should throw a service error when called with only a good name', () => {
+            expect(() => { loadMasterData('chiffres')}).to.throw(Error, SERVICE_SHOULD_BE_A_FUNCTION);
+          });
+
+        });
+        describe('when called with a wrong service parameter and a good name', () => {
+          it('should throw a service error when called with a number', () => {
+              expect(() => { loadMasterData('chiffres', 1)}).to.throw(Error, SERVICE_SHOULD_BE_A_FUNCTION);
+          });
+          it('should throw a service error when called with a string', () => {
+              expect(() => { loadMasterData('chiffres','test')}).to.throw(Error, SERVICE_SHOULD_BE_A_FUNCTION);
+          });
+          it('should throw a service error when called with an array', () => {
+              expect(() => { loadMasterData('chiffres', [1,2,3])}).to.throw(Error, SERVICE_SHOULD_BE_A_FUNCTION);
+          });
+          it('should throw a service error when called with an object', () => {
+              expect(() => { loadMasterData('chiffres', {a: 'a'})}).to.throw(Error, SERVICE_SHOULD_BE_A_FUNCTION);
+          });
+          it('should not throw any service error when called with a good service (and a good name)', () => {
+            expect(() => { loadMasterData('chiffres', MOCKED_SVC)}).to.not.throw(Error);
+          });
+        });
+        describe('when called with a wrong cacheDuration paramaeter an with a good service and name parameters', () => {
+          it('should throw a service error when called with a number', () => {
+              expect(() => { loadMasterData('chiffres', MOCKED_SVC, () => 'lol')}).to.throw(Error, CACHE_DURATION_SHOULD_BE_A_NUMBER);
+          });
+          it('should throw a service error when called with a string', () => {
+              expect(() => { loadMasterData('chiffres',MOCKED_SVC, 'test')}).to.throw(Error, CACHE_DURATION_SHOULD_BE_A_NUMBER);
+          });
+          it('should throw a service error when called with an array', () => {
+              expect(() => { loadMasterData('chiffres',MOCKED_SVC,  [1,2,3])}).to.throw(Error, CACHE_DURATION_SHOULD_BE_A_NUMBER);
+          });
+          it('should throw a service error when called with an object', () => {
+              expect(() => { loadMasterData('chiffres',MOCKED_SVC, {a: 'a'})}).to.throw(Error, CACHE_DURATION_SHOULD_BE_A_NUMBER);
+          });
+          it('should not throw any service error when called with a good service (and a good name)', () => {
+            expect(() => { loadMasterData('chiffres', MOCKED_SVC, 123)}).to.not.throw(Error);
+          });
+
+        });
+
+/*        it('should throw an error when called without a string name parameter', () => {
+            const NAME_MESSAGE = 'ACTION_BUILDER: the name parameter should be a string.';
+            expect(() => { loadMasterData({name: undefined})}).to.throw(NAME_MESSAGE);
+            expect(() => { loadMasterData({name: 1})}).to.throw(NAME_MESSAGE);
+            expect(() => { loadMasterData({name: {}})}).to.throw(NAME_MESSAGE);
+            expect(() => { loadMasterData({name: () => {}})}).to.throw(NAME_MESSAGE);
+            expect(() => { loadMasterData({name: ''})}).to.throw(NAME_MESSAGE);
+            expect(() => { loadMasterData({name: 'test'})}).to.not.throw(NAME_MESSAGE);
+        });
+        it('should throw an error when called without a string type parameter : load,save,delete', () => {
+            const TYPE_MESSAGE = 'ACTION_BUILDER: the type parameter should be a string and the value one of these: load,save,delete.';
+            expect(() => { loadMasterData({name: 'test'})}).to.throw(TYPE_MESSAGE);
+            expect(() => { loadMasterData({name: 'test', type: undefined})}).to.throw(TYPE_MESSAGE);
+            expect(() => { loadMasterData({name: 'test', type: 1})}).to.throw(TYPE_MESSAGE);
+            expect(() => { loadMasterData({name: 'test', type: {}})}).to.throw(TYPE_MESSAGE);
+            expect(() => { loadMasterData({name: 'test', type: () => {}})}).to.throw(TYPE_MESSAGE);
+            expect(() => { loadMasterData({name: 'test', type: ''})}).to.throw(TYPE_MESSAGE);
+            expect(() => { loadMasterData({name: 'test', type: 'nimp'})}).to.throw(TYPE_MESSAGE);
+            expect(() => { loadMasterData({name: 'test', type: 'load'})}).to.not.throw(TYPE_MESSAGE);
+            expect(() => { loadMasterData({name: 'test', type: 'save'})}).to.not.throw(TYPE_MESSAGE);
+            expect(() => { loadMasterData({name: 'test', type: 'delete'})}).to.not.throw(TYPE_MESSAGE);
+        });
+        */
+    });
+  })
+});

--- a/src/actions/__tests__/master-data-test.js
+++ b/src/actions/__tests__/master-data-test.js
@@ -10,7 +10,7 @@ const MOCKED_SVC = () => {
 };
 
 describe('master data actions', () => {
-  describe.only('loadMasterData', () => {
+  describe('loadMasterData', () => {
     describe('when called with wrong parameters', () => {
         it('should throw a LOAD_MASTER_DATA_ACTION  on the name error when called without all parameters', () => {
             expect(() => { loadMasterData()}).to.throw(Error, NAME_SHOULD_BE_A_STRING);

--- a/src/actions/master-data.js
+++ b/src/actions/master-data.js
@@ -1,0 +1,59 @@
+import {isObject} from 'lodash/lang';
+export const REQUEST_MASTER_DATA = 'REQUEST_MASTER_DATA';
+export const RESPONSE_MASTER_DATA = 'RESPONSE_MASTER_DATA';
+export const ERROR_MASTER_DATA = 'ERROR_MASTER_DATA';
+export const SERVE_FROM_CACHE_MASTER_DATA = 'SERVE_FROM_CACHE_MASTER_DATA';
+
+
+export const requestMasterData = name => {
+  return {type: REQUEST_MASTER_DATA, payload: {name}};
+}
+export const responseMasterData = (name, data)  => {
+  return {type: RESPONSE_MASTER_DATA, payload: {name, data}};
+}
+
+export const servedFromCacheMasterData = (name, data)  => {
+  return {type: RESPONSE_MASTER_DATA, payload: {name, data}};
+}
+
+export const errorMasterData = (name, error) => {
+  return {type: ERROR_MASTER_DATA, payload: {name, error}};
+}
+const DEFAULT_CACHE_DURATION = 1000 * 60; //1 min
+const _cache = {};
+
+const _getTimeStamp = () => new Date().getTime();
+const _isDataInCache = name => {
+  const cachedData = _cache[name];
+  return isObject(cachedData) && _getTimeStamp() - cachedData.timeStamp < cachedData.cacheDuration;
+};
+
+async const _getDataFromCache =  name => {
+  return Promise.resolve(_cache[name].value);
+}
+const _setDataInCache = (name, value, cacheDuration = DEFAULT_CACHE_DURATION) => {
+  _cache[name] = {name, value, cacheDuration, timeStamp: _getTimeStamp()};
+  return value;
+}
+
+export async const loadMasterData(name, service, cacheDuration = DEFAULT_CACHE_DURATION) => {
+    requestMasterData(name);
+    try {
+      if(_isDataInCache(name)){
+          //Question is the cache usefull as this data will be in the app state.
+          // Maybe we should only keep the timestamp and the name
+          // This is usefull only for debug prupose.
+          const cached = await _getDataFromCache(name);
+          servedFromCacheMasterData(name, cached);
+      }
+      else {
+        const res = await service().then(d => _setDataInCache(name, d, cacheDuration));
+        responseMasterData(name, res);
+      }
+    } catch(err){
+      errorMasterData(name, err)
+    }
+};
+
+//Create a builder of master data action
+// This builder should take into account the config of the provider which will call a set action.

--- a/src/actions/master-data.js
+++ b/src/actions/master-data.js
@@ -44,7 +44,6 @@ const _validateLoadMasterData = (name, service, cacheDuration) => {
 export const loadMasterData = (name, service, cacheDuration = DEFAULT_CACHE_DURATION) => {
     _validateLoadMasterData(name, service, cacheDuration);
     return async dispatch => {
-      dispatch(requestMasterData(name));
       try {
         if(_isDataInCache(name)){
           //Question is the cache usefull as this data will be in the app state.
@@ -55,10 +54,9 @@ export const loadMasterData = (name, service, cacheDuration = DEFAULT_CACHE_DURA
           //servedFromCacheMasterData(name, cached);
         }
         else {
-          const res = await service().then(d => {
-            _setDataInCache(name, cacheDuration)
-            return d;
-          });
+          dispatch(requestMasterData(name));
+          const res = await service()
+          _setDataInCache(name, cacheDuration);
           dispatch(responseMasterData(name, res));
         }
       } catch(err){

--- a/src/behaviours/__tests__/master-data-test.js
+++ b/src/behaviours/__tests__/master-data-test.js
@@ -1,0 +1,134 @@
+import React, {PropTypes} from 'react';
+import {connect, Provider} from '../master-data';
+
+const MASTER_DATA_PROPTYPE = PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      service: PropTypes.func.isRequired,
+      cacheDuration: PropTypes.number
+})).isRequired;
+
+
+describe('Definition behaviour', () => {
+    describe('The definitions provider', () => {
+        let component;
+        const TestComponent = (props, context) => <div id='testContent'>{JSON.stringify(context)}</div>;
+        const _tryRenderProviderWithProps = props => {
+          const shallowRenderer = TestUtils.createRenderer();
+          shallowRenderer.render(<Provider {...props}><TestComponent /></Provider>);
+          return shallowRenderer.getRenderOutput();
+      };
+        it('should be a class', () => {
+           expect(Provider).to.be.a('function');
+       });
+        it('should be a react component with childContextTypes', () => {
+           expect(Provider.childContextTypes).to.deep.equal({
+             masterDataLoaders: MASTER_DATA_PROPTYPE
+         })
+       });
+       it('should be a react component with propTypes', () => {
+          expect(Provider.propTypes).to.deep.equal({
+            configuration: MASTER_DATA_PROPTYPE
+        })
+      });
+
+        it('should be a class with getChildContext method', () => {
+           expect(Provider.prototype.getChildContext).to.be.a('function');
+       });
+        /*it('should render a React component', () => {
+           component = _tryRenderProviderWithProps({definitions:{test: {name: 'test'}}});
+           expect(component).to.be.an('object');
+           expect(component.type).to.be.equal(TestComponent);
+       });*/
+
+    });
+
+/*
+    describe('The connect to definitions', () => {
+      describe('the connect function', () => {
+        const CONNECTOR_VALIDATION_MESSAGE = 'BEHAVIOUR_DEFINITION_CONNECT:  The definition name should be a string or an array of strings.';
+        it('should be a function', () => {
+          expect(connect).to.be.a('function');
+      });
+        it('should accept a string parameter and return a connector', () => {
+          expect(connect('n1')).to.be.a('function');
+      });
+        it('should not accept a number parameter', () => {
+          expect(() => connect(1)).to.throw(CONNECTOR_VALIDATION_MESSAGE);
+      });
+        it('should not accept a number parameter', () => {
+          expect(() => connect(() => {})).to.throw(CONNECTOR_VALIDATION_MESSAGE);
+      });
+        it('should not accept an empty string parameter', () => {
+          expect(() => connect('')).to.throw(CONNECTOR_VALIDATION_MESSAGE);
+      });
+        it('should not accept an empty array parameter', () => {
+          expect(() => connect([])).to.throw(CONNECTOR_VALIDATION_MESSAGE);
+      });
+        it('should accept an array of string parameter and return a connector', () => {
+          expect(connect(['n1', 'n2'])).to.be.a('function');
+      });
+    });
+      describe('the connectComponentToDefinitions function', () => {
+        const TestComponent = props => <pre><code>{JSON.stringify(props)}</code></pre>;
+        TestComponent.displayName = 'TestComponent';
+        const _tryRenderWithDefinitionContext = (toRender, context) => {
+          const shallowRenderer = TestUtils.createRenderer();
+          shallowRenderer.render(toRender(), context);
+          return shallowRenderer.getRenderOutput();
+      };
+        const NO_DEF_MSG = 'BEHAVIOUR_DEFINITION_CONNECT The definitions must be an object check your **DefinitionsProvider**';
+        it('should return a react component', () => {
+          const ConnectedTestComponent = connect('n1')(TestComponent);
+          expect(ConnectedTestComponent).to.be.a('function');
+      });
+        describe('when rendered with a wrong context', () => {
+          it('should throw an error when there is no context', () => {
+            const ConnectedTestComponent = connect('n1')(TestComponent);
+            expect(
+            () => _tryRenderWithDefinitionContext(
+              () => <ConnectedTestComponent />,
+              null
+            )
+          ).to.throw(NO_DEF_MSG)
+        })
+          it('should throw an error when there are no definitions', () => {
+            expect(() => _tryRenderWithDefinitionContext(() => <ConnectedTestComponent />, {})).to.throw('ConnectedTestComponent is not defined')
+        })
+          it('should throw an error when the requested definition is not present', () => {
+            const WRONG_DEF_MSG = 'BEHAVIOUR_DEFINITION_CONNECT The definition you requested : nimp does not exists or is not an object, check your **DefinitionsProvider**';
+            const ConnectedTestComponent = connect('nimp')(TestComponent);
+            expect(
+            () => _tryRenderWithDefinitionContext(
+              () => <ConnectedTestComponent />,
+              {definitions: {n1: {domain: 'PAPA'}}}
+            )
+          ).to.throw(WRONG_DEF_MSG);
+        })
+      });
+        describe('render with a correct definitionContext', () => {
+          const DEFINITIONS = {n1: {f1:{domain: 'DO_LOPEZ'}, f2:{domain: 'DO_JOE'}}, n2: {f1:{domain: 'DO_DAVID'}, f2:{domain: 'DO_DIEGO'}}}
+          const ConnectedTestComponent = connect('n1')(TestComponent);
+          const component = _tryRenderWithDefinitionContext(() => <ConnectedTestComponent/>, {definitions: DEFINITIONS});
+          it('should render a component', () => {
+            expect(component).to.be.a('object');
+        });
+          it('should render a component with props', () => {
+            expect(component.props).to.be.a('object');
+        });
+          it('should have the _behaviours{isConnectedToDefinition} as props', () => {
+            const {_behaviours} = component.props;
+            expect(_behaviours).to.be.a('object');
+            expect(_behaviours.isConnectedToDefinition).to.be.a('boolean');
+            expect(_behaviours.isConnectedToDefinition).to.be.equal(true);
+        })
+          it('should have the definition as props', () => {
+            const {definition} = component.props;
+            expect(definition).to.be.a('object');
+            expect(definition).to.be.deep.equal(DEFINITIONS.n1);
+        });
+      });
+    });
+  });
+  */
+});

--- a/src/behaviours/__tests__/master-data-test.js
+++ b/src/behaviours/__tests__/master-data-test.js
@@ -9,8 +9,8 @@ const MASTER_DATA_PROPTYPE = PropTypes.arrayOf(
 })).isRequired;
 
 
-describe('Definition behaviour', () => {
-    describe('The definitions provider', () => {
+describe('The master data behaviour', () => {
+    describe('The master data provider', () => {
         let component;
         const TestComponent = (props, context) => <div id='testContent'>{JSON.stringify(context)}</div>;
         const _tryRenderProviderWithProps = props => {
@@ -22,113 +22,46 @@ describe('Definition behaviour', () => {
            expect(Provider).to.be.a('function');
        });
         it('should be a react component with childContextTypes', () => {
-           expect(Provider.childContextTypes).to.deep.equal({
-             masterDataLoaders: MASTER_DATA_PROPTYPE
-         })
+           expect(Provider.childContextTypes.masterDataLoaders).to.be.a.function;//.to.deep.equal(MASTER_DATA_PROPTYPE)
        });
        it('should be a react component with propTypes', () => {
-          expect(Provider.propTypes).to.deep.equal({
-            configuration: MASTER_DATA_PROPTYPE
-        })
+          expect(Provider.propTypes.configuration).be.a.function;//to.equal(MASTER_DATA_PROPTYPE)
       });
 
         it('should be a class with getChildContext method', () => {
            expect(Provider.prototype.getChildContext).to.be.a('function');
        });
-        /*it('should render a React component', () => {
-           component = _tryRenderProviderWithProps({definitions:{test: {name: 'test'}}});
+      it('should render a React component', () => {
+           component = _tryRenderProviderWithProps({configuration:[{name: 'chiffres', service: ()=> Promise.resolve([1,2,3])}]});
            expect(component).to.be.an('object');
            expect(component.type).to.be.equal(TestComponent);
-       });*/
+       })
 
     });
 
-/*
-    describe('The connect to definitions', () => {
+    describe('The connector to the masterData', () => {
       describe('the connect function', () => {
-        const CONNECTOR_VALIDATION_MESSAGE = 'BEHAVIOUR_DEFINITION_CONNECT:  The definition name should be a string or an array of strings.';
+        const CONNECTOR_VALIDATION_MESSAGE_NOT_AN_ARRAY = 'MASTER_DATA_CONNECT: the names property must be an array.';
+        const CONNECTOR_VALIDATION_MESSAGE_EMPTY_ARRAY = 'MASTER_DATA_CONNECT: the names property must contain at least a name.';
         it('should be a function', () => {
-          expect(connect).to.be.a('function');
+            expect(connect).to.be.a('function');
+        });
+          it('should not accept a number parameter', () => {
+            expect(() => connect(1)).to.throw(CONNECTOR_VALIDATION_MESSAGE_NOT_AN_ARRAY);
+        });
+          it('should not accept a function parameter', () => {
+            expect(() => connect(() => {})).to.throw(CONNECTOR_VALIDATION_MESSAGE_NOT_AN_ARRAY);
+        });
+          it('should not accept an empty array parameter', () => {
+            expect(() => connect([])).to.throw(CONNECTOR_VALIDATION_MESSAGE_EMPTY_ARRAY);
+        });
+          it('should not accept a string  parameter', () => {
+            expect(() => connect('n1')).to.throw(CONNECTOR_VALIDATION_MESSAGE_NOT_AN_ARRAY);
+        });
+          it('should accept an array of string parameter and return a connector', () => {
+            expect(connect(['n1', 'n2'])).to.be.a('function');
+        });
       });
-        it('should accept a string parameter and return a connector', () => {
-          expect(connect('n1')).to.be.a('function');
-      });
-        it('should not accept a number parameter', () => {
-          expect(() => connect(1)).to.throw(CONNECTOR_VALIDATION_MESSAGE);
-      });
-        it('should not accept a number parameter', () => {
-          expect(() => connect(() => {})).to.throw(CONNECTOR_VALIDATION_MESSAGE);
-      });
-        it('should not accept an empty string parameter', () => {
-          expect(() => connect('')).to.throw(CONNECTOR_VALIDATION_MESSAGE);
-      });
-        it('should not accept an empty array parameter', () => {
-          expect(() => connect([])).to.throw(CONNECTOR_VALIDATION_MESSAGE);
-      });
-        it('should accept an array of string parameter and return a connector', () => {
-          expect(connect(['n1', 'n2'])).to.be.a('function');
-      });
+
     });
-      describe('the connectComponentToDefinitions function', () => {
-        const TestComponent = props => <pre><code>{JSON.stringify(props)}</code></pre>;
-        TestComponent.displayName = 'TestComponent';
-        const _tryRenderWithDefinitionContext = (toRender, context) => {
-          const shallowRenderer = TestUtils.createRenderer();
-          shallowRenderer.render(toRender(), context);
-          return shallowRenderer.getRenderOutput();
-      };
-        const NO_DEF_MSG = 'BEHAVIOUR_DEFINITION_CONNECT The definitions must be an object check your **DefinitionsProvider**';
-        it('should return a react component', () => {
-          const ConnectedTestComponent = connect('n1')(TestComponent);
-          expect(ConnectedTestComponent).to.be.a('function');
-      });
-        describe('when rendered with a wrong context', () => {
-          it('should throw an error when there is no context', () => {
-            const ConnectedTestComponent = connect('n1')(TestComponent);
-            expect(
-            () => _tryRenderWithDefinitionContext(
-              () => <ConnectedTestComponent />,
-              null
-            )
-          ).to.throw(NO_DEF_MSG)
-        })
-          it('should throw an error when there are no definitions', () => {
-            expect(() => _tryRenderWithDefinitionContext(() => <ConnectedTestComponent />, {})).to.throw('ConnectedTestComponent is not defined')
-        })
-          it('should throw an error when the requested definition is not present', () => {
-            const WRONG_DEF_MSG = 'BEHAVIOUR_DEFINITION_CONNECT The definition you requested : nimp does not exists or is not an object, check your **DefinitionsProvider**';
-            const ConnectedTestComponent = connect('nimp')(TestComponent);
-            expect(
-            () => _tryRenderWithDefinitionContext(
-              () => <ConnectedTestComponent />,
-              {definitions: {n1: {domain: 'PAPA'}}}
-            )
-          ).to.throw(WRONG_DEF_MSG);
-        })
-      });
-        describe('render with a correct definitionContext', () => {
-          const DEFINITIONS = {n1: {f1:{domain: 'DO_LOPEZ'}, f2:{domain: 'DO_JOE'}}, n2: {f1:{domain: 'DO_DAVID'}, f2:{domain: 'DO_DIEGO'}}}
-          const ConnectedTestComponent = connect('n1')(TestComponent);
-          const component = _tryRenderWithDefinitionContext(() => <ConnectedTestComponent/>, {definitions: DEFINITIONS});
-          it('should render a component', () => {
-            expect(component).to.be.a('object');
-        });
-          it('should render a component with props', () => {
-            expect(component.props).to.be.a('object');
-        });
-          it('should have the _behaviours{isConnectedToDefinition} as props', () => {
-            const {_behaviours} = component.props;
-            expect(_behaviours).to.be.a('object');
-            expect(_behaviours.isConnectedToDefinition).to.be.a('boolean');
-            expect(_behaviours.isConnectedToDefinition).to.be.equal(true);
-        })
-          it('should have the definition as props', () => {
-            const {definition} = component.props;
-            expect(definition).to.be.a('object');
-            expect(definition).to.be.deep.equal(DEFINITIONS.n1);
-        });
-      });
-    });
-  });
-  */
 });

--- a/src/behaviours/master-data.js
+++ b/src/behaviours/master-data.js
@@ -9,7 +9,7 @@ class MasterDataProvider extends Component {
   constructor(props) {
     super(props);
     this._loaders = props.configuration.reduce((res, current) => {
-        res[current.name] = () => _loadMasterData(name, current.service, current.cacheDuration);
+        res[current.name] = () => loadMasterData(name, current.service, current.cacheDuration);
         return res;
     });
   }

--- a/src/behaviours/master-data.js
+++ b/src/behaviours/master-data.js
@@ -1,0 +1,39 @@
+import React, {Component, PropTypes} from 'react';
+import {loadMasterData} from '../actions/master-data';
+
+const MASTER_DATA_CONTEXT_TYPE = {
+  masterDataloaders: PropTypes.object
+}
+
+class MasterDataProvider extends Component {
+  constructor(props) {
+    super(props);
+    this._loaders = props.configuration.reduce((res, current) => {
+        res[current.name] = () => _loadMasterData(name, current.service, current.cacheDuration);
+        return res;
+    });
+  }
+  getChildContext() {
+      return {
+        masterDataloaders: this._loaders
+    }
+  }
+    render() {
+      return this.props.children;
+  }
+}
+
+MasterDataProvider.childContextTypes = MASTER_DATA_CONTEXT_TYPE;
+MasterDataProvider.defaultProps = {configuration: []}
+
+MasterDataProvider.propTypes = {
+  configuration:  PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        service: PropTypes.func.isRequired,
+        cacheDuration: PropTypes.number
+    })
+  ).isRequired;
+};
+
+export const Provider = DefinitionsProvider;

--- a/src/behaviours/master-data.js
+++ b/src/behaviours/master-data.js
@@ -1,21 +1,48 @@
 import React, {Component, PropTypes} from 'react';
 import {loadMasterData} from '../actions/master-data';
+import {pick} from 'lodash/object';
+
+const MASTER_DATA_PROPTYPE = PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      service: PropTypes.func.isRequired,
+      cacheDuration: PropTypes.number
+})).isRequired;
 
 const MASTER_DATA_CONTEXT_TYPE = {
-  masterDataloaders: PropTypes.object
+  masterDataloaders: MASTER_DATA_PROPTYPE
 }
 
-class MasterDataProvider extends Component {
-  constructor(props) {
-    super(props);
-    this._loaders = props.configuration.reduce((res, current) => {
-        res[current.name] = () => loadMasterData(name, current.service, current.cacheDuration);
-        return res;
-    });
+
+// Connect the component to the load method of the master data.
+const connectMasterData = (names) => {
+  return function connectComponent(ComponentToConnect) {
+      function MasterDataConnectedComponent(props, {masterDataloaders}) {
+        console.log(masterDataloaders);
+        const wantedMasterDataLoaders = masterDataloaders.reduce((res, current) => {
+              if(names.indexOf(current.name) !== -1){
+                res[`loadMasterData${current.name}`] = () => loadMasterData(current.name, current.service, current.cacheDuration);
+              }
+              return res;
+          }, {});
+          const {_behaviours, ...otherProps} = props;
+          const behaviours = {isConnectedMasterData: true, ..._behaviours}
+          console.log('wantedMasterDataLoaders', masterDataloaders, wantedMasterDataLoaders);
+          return <ComponentToConnect {...otherProps} {...wantedMasterDataLoaders} _behaviours={behaviours} />;
+      }
+      MasterDataConnectedComponent.displayName = `${ComponentToConnect.displayName}MasterDataConnectedComponent`;
+      MasterDataConnectedComponent.contextTypes = MASTER_DATA_CONTEXT_TYPE;
+      return MasterDataConnectedComponent;
   }
+
+};
+export const connect = connectMasterData;
+
+
+class MasterDataProvider extends Component {
   getChildContext() {
       return {
-        masterDataloaders: this._loaders
+        masterDataloaders: this.props.configuration
     }
   }
     render() {
@@ -27,13 +54,7 @@ MasterDataProvider.childContextTypes = MASTER_DATA_CONTEXT_TYPE;
 MasterDataProvider.defaultProps = {configuration: []}
 
 MasterDataProvider.propTypes = {
-  configuration:  PropTypes.arrayOf(
-      PropTypes.shape({
-        name: PropTypes.string.isRequired,
-        service: PropTypes.func.isRequired,
-        cacheDuration: PropTypes.number
-    })
-  ).isRequired;
+  configuration: MASTER_DATA_PROPTYPE
 };
 
-export const Provider = DefinitionsProvider;
+export const Provider = MasterDataProvider;

--- a/src/behaviours/master-data.js
+++ b/src/behaviours/master-data.js
@@ -35,7 +35,7 @@ const connectMasterData = (names = []) => {
               return res;
           }, {});
           if(Object.keys(wantedMasterDataLoaders) === 0){
-            console.warn(`connectMasterData: your keys ${Object.keys(names)} are not in the masterDataLoaders ${masterDataLoaders.reduce((res, current) => [...res, current.name]), [])}`)
+            console.warn(`connectMasterData: your keys ${Object.keys(names)} are not in the masterDataLoaders ${masterDataLoaders.reduce((res, current) => [...res, current.name], [])}`)
           }
           const {_behaviours, ...otherProps} = props;
           const behaviours = {isConnectedMasterData: true, ..._behaviours}

--- a/src/behaviours/master-data.js
+++ b/src/behaviours/master-data.js
@@ -1,8 +1,9 @@
 import React, {Component, PropTypes} from 'react';
 import {loadMasterData} from '../actions/master-data';
 import {pick} from 'lodash/object';
+import {isArray} from 'lodash/lang';
 import {capitalize} from 'lodash/string';
-
+const MASTER_DATA_CONNECT = 'MASTER_DATA_CONNECT';
 const MASTER_DATA_PROPTYPE = PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string.isRequired,
@@ -26,6 +27,12 @@ const MASTER_DATA_CONTEXT_TYPE = {
 //const MyMasterDataConnectedComponent =  connectMasterData(['sandwichTypes'])(MyComponentWhichUsesAMasterDataLoader)
 //```
 const connectMasterData = (names = []) => {
+  if(!isArray(names)){
+    throw new Error(`${MASTER_DATA_CONNECT}: the names property must be an array.`);
+  }
+  if(names.length === 0){
+    throw new Error(`${MASTER_DATA_CONNECT}: the names property must contain at least a name.`);
+  }
   return function connectComponent(ComponentToConnect) {
       const MasterDataConnectedComponent = (props, {masterDataLoaders}) => {
           const wantedMasterDataLoaders = masterDataLoaders.reduce((res, current) => {

--- a/src/behaviours/master-data.js
+++ b/src/behaviours/master-data.js
@@ -1,6 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import {loadMasterData} from '../actions/master-data';
 import {pick} from 'lodash/object';
+import {capitalize} from 'lodash/string';
 
 const MASTER_DATA_PROPTYPE = PropTypes.arrayOf(
     PropTypes.shape({
@@ -10,24 +11,35 @@ const MASTER_DATA_PROPTYPE = PropTypes.arrayOf(
 })).isRequired;
 
 const MASTER_DATA_CONTEXT_TYPE = {
-  masterDataloaders: MASTER_DATA_PROPTYPE
+  masterDataLoaders: MASTER_DATA_PROPTYPE
 }
 
 
 // Connect the component to the load method of the master data.
-const connectMasterData = (names) => {
+// You have to pass an array of names in which you are interested.
+// These names should correspond to the configuration you provide to the `MasterDataProvider`.
+// It add as props to the connected component the loaders for each requested master data with the name `loadMasterDataName`
+// Where name is what you give to the names property of the connector.
+// Example Call
+//```jsx
+//  const MyComponentWhichUsesAMasterDataLoader = (props) => <div><button = >LoadMyList</button>{props.name}</div>;
+// const MyMasterDataConnectedComponent =  connectMasterData(['sandwichTypes'])(MyComponentWhichUsesAMasterDataLoader)
+//```
+
+const connectMasterData = (names = []) => {
   return function connectComponent(ComponentToConnect) {
-      function MasterDataConnectedComponent(props, {masterDataloaders}) {
-        console.log(masterDataloaders);
-        const wantedMasterDataLoaders = masterDataloaders.reduce((res, current) => {
+      const MasterDataConnectedComponent = (props, {masterDataLoaders}) => {
+          const wantedMasterDataLoaders = masterDataLoaders.reduce((res, current) => {
               if(names.indexOf(current.name) !== -1){
-                res[`loadMasterData${current.name}`] = () => loadMasterData(current.name, current.service, current.cacheDuration);
+                res[`loadMasterData${capitalize(current.name)}`] = () => loadMasterData(current.name, current.service, current.cacheDuration);
               }
               return res;
           }, {});
+          if(Object.keys(wantedMasterDataLoaders) === 0){
+            console.warn(`connectMasterData: your keys ${Object.keys(names)} are not in the masterDataLoaders ${masterDataLoaders.reduce((res, current) => [...res, current.name]), [])}`)
+          }
           const {_behaviours, ...otherProps} = props;
           const behaviours = {isConnectedMasterData: true, ..._behaviours}
-          console.log('wantedMasterDataLoaders', masterDataloaders, wantedMasterDataLoaders);
           return <ComponentToConnect {...otherProps} {...wantedMasterDataLoaders} _behaviours={behaviours} />;
       }
       MasterDataConnectedComponent.displayName = `${ComponentToConnect.displayName}MasterDataConnectedComponent`;
@@ -38,16 +50,27 @@ const connectMasterData = (names) => {
 };
 export const connect = connectMasterData;
 
-
+// MasterDataProvider.
+// Add behaviour to set the master data config: `MasterDataProvider`,
+// the provider put in the context the array which is named `masterDataLoaders`,
+// you have to pass to the provider the following configuration:
+//`configuration = [{name, service, cacheDuration}]`
+// which will be passed in the `masterDataLoaders`
+// Example Call
+//```jsx
+//<MasterDataProvider config={[{name: 'sandwichType', service: loadSandwichType}, {name: 'civility', service: loadChiffres}]}>
+//  <MyMasterDataConnectedDumbComponent />
+//</MasterDataProvider>
+//```
 class MasterDataProvider extends Component {
-  getChildContext() {
-      return {
-        masterDataloaders: this.props.configuration
+    getChildContext() {
+        return {
+          masterDataLoaders: this.props.configuration
+      }
     }
-  }
     render() {
-      return this.props.children;
-  }
+        return this.props.children;
+    }
 }
 
 MasterDataProvider.childContextTypes = MASTER_DATA_CONTEXT_TYPE;

--- a/src/behaviours/master-data.js
+++ b/src/behaviours/master-data.js
@@ -22,10 +22,9 @@ const MASTER_DATA_CONTEXT_TYPE = {
 // Where name is what you give to the names property of the connector.
 // Example Call
 //```jsx
-//  const MyComponentWhichUsesAMasterDataLoader = (props) => <div><button = >LoadMyList</button>{props.name}</div>;
-// const MyMasterDataConnectedComponent =  connectMasterData(['sandwichTypes'])(MyComponentWhichUsesAMasterDataLoader)
+//const MyComponentWhichUsesAMasterDataLoader = (props) => <div><button = >LoadMyList</button>{props.name}</div>;
+//const MyMasterDataConnectedComponent =  connectMasterData(['sandwichTypes'])(MyComponentWhichUsesAMasterDataLoader)
 //```
-
 const connectMasterData = (names = []) => {
   return function connectComponent(ComponentToConnect) {
       const MasterDataConnectedComponent = (props, {masterDataLoaders}) => {

--- a/src/example/components/user-dumb.js
+++ b/src/example/components/user-dumb.js
@@ -2,6 +2,7 @@ import React, {Component, PropTypes} from 'react';
 import {connect as formConnect } from '../../behaviours/form';
 import {connect as connectToDefinitions} from '../../behaviours/definitions';
 import {connect as connectToFieldHelpers} from '../../behaviours/field';
+import {connect as connectToMasterData} from '../../behaviours/master-data';
 import {loadUserAction, saveUserAction} from '../actions/user-actions';
 
 // Dumb components
@@ -11,11 +12,14 @@ import Button from './button';
 import Code from './code';
 import compose from 'lodash/flowRight';
 
-function UserDumbComponent({fields, fieldFor, load, save, id, getUserInput, ...otherProps}) {
+function UserDumbComponent({fields, fieldFor, load, save, id, getUserInput, loadMasterData, ...otherProps}) {
+    console.log('otherProps');
     return (
         <div>
             {/* Fields auto rendering to test direct rendering without helpers*/}
             <Button onClick={() => {load({id})}}>Load entity from server</Button>
+            {/* Load the  */}
+            <Button onClick={() => loadMasterData()}>Load master data</Button>
             {fieldFor('uuid', {onChange: () => {console.log(fields)}})}
             {fieldFor('firstName')}
             {fieldFor('lastName')}
@@ -36,6 +40,7 @@ const formConfig = {
 //Connect the component to all its behaviours (respect the order for store, store -> props, helper)
 const ConnectedUserDumbComponent = compose(
     connectToDefinitions('user'),
+    connectToMasterData(['civility']),
     formConnect(formConfig),
     connectToFieldHelpers()
 )(UserDumbComponent);

--- a/src/example/index.js
+++ b/src/example/index.js
@@ -8,9 +8,10 @@ import ReactDOM from 'react-dom';
 import {Provider as StoreProvider} from 'react-redux';
 import {Provider as DefinitionsProvider} from '../behaviours/definitions';
 import {Provider as FieldHelpersProvider} from '../behaviours/field';
+import {Provider as MasterDataProvider} from '../behaviours/master-data';
 import UserDumbComponent from './components/user-dumb';
 import DevTools from './containers/dev-tools';
-
+import {loadCivility} from './services/load-civility';
 import store from './store';
 
 const definitions = {
@@ -24,6 +25,7 @@ const App = () => {
     return (
         <DefinitionsProvider definitions={definitions}>
             <StoreProvider store={store}>
+              <MasterDataProvider configuration={[{name: 'civility', service: loadCivility}]}>
                 <div>
                     <DevTools />
                     <FieldHelpersProvider>
@@ -33,6 +35,7 @@ const App = () => {
                         </div>
                     </FieldHelpersProvider>
                 </div>
+              </MasterDataProvider>
             </StoreProvider>
         </DefinitionsProvider>
     )

--- a/src/example/services/load-civility.js
+++ b/src/example/services/load-civility.js
@@ -1,0 +1,4 @@
+export const loadCivility = () => {
+  console.log('called')
+  return Promise.resolve([{code: 'MR', label: 'Mr'}, {code: 'Mme', label: 'Mme'}])
+};

--- a/src/example/services/load-civility.js
+++ b/src/example/services/load-civility.js
@@ -1,4 +1,1 @@
-export const loadCivility = () => {
-  console.log('called')
-  return Promise.resolve([{code: 'MR', label: 'Mr'}, {code: 'Mme', label: 'Mme'}])
-};
+export const loadCivility = () => Promise.resolve([{code: 'MR', label: 'Mr'}, {code: 'Mme', label: 'Mme'}]);

--- a/src/reducers/__tests__/master-data-reducer-test.js
+++ b/src/reducers/__tests__/master-data-reducer-test.js
@@ -3,7 +3,7 @@ import masterDataReducer from '../master-data';
 import {isArray} from 'lodash/lang'
 const EMPY_INITIAL_STATE  = [];
 const MOCK_VALUE_MASTER_DATA = [{code: 1, label: 'Un'}, {code: 2, label: 'Deux'}];
-describe.only('The master data reducer', () => {
+describe('The master data reducer', () => {
 
     describe('when receiving an unknown action with no initial state', () => {
       const newState = masterDataReducer();

--- a/src/reducers/__tests__/master-data-reducer-test.js
+++ b/src/reducers/__tests__/master-data-reducer-test.js
@@ -35,7 +35,7 @@ describe.only('The master data reducer', () => {
         const updateItem = {
           name: ACTION_REQUEST_MASTER_DATA.name,
           value: ACTION_REQUEST_MASTER_DATA.value,
-          isLoading: true
+          loading: true
         };
         describe('when the state does not contain the master data', () => {
           const INITIAL_STATE = [{name: 'A', value: 'a'}]
@@ -58,4 +58,39 @@ describe.only('The master data reducer', () => {
           });
         });
     });
+
+
+    describe('when receiving an action with RESPONSE_MASTER_DATA', () => {
+        const ACTION_RESPONSE_MASTER_DATA = {
+          type: RESPONSE_MASTER_DATA,
+          value: MOCK_VALUE_MASTER_DATA,
+          name: 'chiffres'
+        };
+        const updateItem = {
+          name: ACTION_RESPONSE_MASTER_DATA.name,
+          value: ACTION_RESPONSE_MASTER_DATA.value,
+          loading: false
+        };
+        describe('when the state does not contain the master data', () => {
+          const INITIAL_STATE = [{name: 'A', value: 'a'}]
+          const newState = masterDataReducer(INITIAL_STATE, ACTION_RESPONSE_MASTER_DATA);
+          it('shoud return a new array with the new master data in the **loading** state', () => {
+            expect(newState).to.be.an.array;
+            expect(newState.length).to.equal(INITIAL_STATE.length + 1);
+            expect(newState.find(m => m.name === ACTION_RESPONSE_MASTER_DATA.name))
+            .to.deep.equal(updateItem);
+          });
+        });
+        describe('when the state contains the master data', () => {
+          const INITIAL_STATE = [{name: 'A', value: 'a'}, {name: 'chiffres', value: [{code: 'lol', value: 'lol'}]}];
+          const newState = masterDataReducer(INITIAL_STATE, ACTION_RESPONSE_MASTER_DATA);
+          it('should return a new array of the same length with an updated master data in the **loading** state', () => {
+            expect(newState).to.be.an.array;
+            expect(newState.length).to.equal(INITIAL_STATE.length);
+            expect(newState.find(m => m.name === ACTION_RESPONSE_MASTER_DATA.name))
+            .to.deep.equal(updateItem);
+          });
+        });
+    });
+
 });

--- a/src/reducers/__tests__/master-data-reducer-test.js
+++ b/src/reducers/__tests__/master-data-reducer-test.js
@@ -1,0 +1,61 @@
+import {REQUEST_MASTER_DATA, RESPONSE_MASTER_DATA, ERROR_MASTER_DATA} from '../../actions/master-data';
+import masterDataReducer from '../master-data';
+import {isArray} from 'lodash/lang'
+const EMPY_INITIAL_STATE  = [];
+const MOCK_VALUE_MASTER_DATA = [{code: 1, label: 'Un'}, {code: 2, label: 'Deux'}];
+describe.only('The master data reducer', () => {
+
+    describe('when receiving an unknown action with no initial state', () => {
+      const newState = masterDataReducer();
+      it('should return an array', () => {
+          expect(isArray(newState)).to.be.true;
+      });
+    });
+
+    describe('when receiving an unknown action with an initial state', () => {
+        const INITIAL_STATE = [{name: 'A', value: 'a'}];
+        const newState = masterDataReducer(INITIAL_STATE);
+        it('should return the initial state', () => {
+            expect(newState).to.equal(INITIAL_STATE);
+        });
+    });
+
+    describe('when receiving an action with an unknown type', () => {
+        const newState = masterDataReducer(EMPY_INITIAL_STATE, {type: 'UNKNOWN'});
+        it('should return the initial state', () => {
+            expect(newState).to.equal(EMPY_INITIAL_STATE);
+        });
+    });
+    describe('when receiving an action with REQUEST_MASTER_DATA', () => {
+        const ACTION_REQUEST_MASTER_DATA = {
+          type: REQUEST_MASTER_DATA,
+          value: MOCK_VALUE_MASTER_DATA,
+          name: 'chiffres'
+        };
+        const updateItem = {
+          name: ACTION_REQUEST_MASTER_DATA.name,
+          value: ACTION_REQUEST_MASTER_DATA.value,
+          isLoading: true
+        };
+        describe('when the state does not contain the master data', () => {
+          const INITIAL_STATE = [{name: 'A', value: 'a'}]
+          const newState = masterDataReducer(INITIAL_STATE, ACTION_REQUEST_MASTER_DATA);
+          it('shoud return a new array with the new master data in the **loading** state', () => {
+            expect(newState).to.be.an.array;
+            expect(newState.length).to.equal(INITIAL_STATE.length + 1);
+            expect(newState.find(m => m.name === ACTION_REQUEST_MASTER_DATA.name))
+            .to.deep.equal(updateItem);
+          });
+        });
+        describe('when the state contains the master data', () => {
+          const INITIAL_STATE = [{name: 'A', value: 'a'}, {name: 'chiffres', value: [{code: 'lol', value: 'lol'}]}];
+          const newState = masterDataReducer(INITIAL_STATE, ACTION_REQUEST_MASTER_DATA);
+          it('should return a new array of the same length with an updated master data in the **loading** state', () => {
+            expect(newState).to.be.an.array;
+            expect(newState.length).to.equal(INITIAL_STATE.length);
+            expect(newState.find(m => m.name === ACTION_REQUEST_MASTER_DATA.name))
+            .to.deep.equal(updateItem);
+          });
+        });
+    });
+});

--- a/src/reducers/__tests__/master-data-reducer-test.js
+++ b/src/reducers/__tests__/master-data-reducer-test.js
@@ -93,4 +93,38 @@ describe.only('The master data reducer', () => {
         });
     });
 
+    describe('when receiving an action with ERROR_MASTER_DATA', () => {
+        const ACTION_ERROR_MASTER_DATA = {
+          type: ERROR_MASTER_DATA,
+          error: 'Problem during the list loading',
+          name: 'chiffres'
+        };
+        const updateItem = {
+          name: ACTION_ERROR_MASTER_DATA.name,
+          error: ACTION_ERROR_MASTER_DATA.error,
+          loading: false
+        };
+        describe('when the state does not contain the master data', () => {
+          const INITIAL_STATE = [{name: 'A', value: 'a'}]
+          const newState = masterDataReducer(INITIAL_STATE, ACTION_ERROR_MASTER_DATA);
+          it('shoud return a new array with the new master data in the **loading** state', () => {
+            expect(newState).to.be.an.array;
+            expect(newState.length).to.equal(INITIAL_STATE.length + 1);
+            expect(newState.find(m => m.name === ACTION_ERROR_MASTER_DATA.name))
+            .to.deep.equal(updateItem);
+          });
+        });
+        describe('when the state contains the master data', () => {
+          const INITIAL_STATE = [{name: 'A', value: 'a'}, {name: 'chiffres', value: [{code: 'lol', value: 'lol'}]}];
+          const newState = masterDataReducer(INITIAL_STATE, ACTION_ERROR_MASTER_DATA);
+          it('should return a new array of the same length with an updated master data in the **loading** state', () => {
+            expect(newState).to.be.an.array;
+            expect(newState.length).to.equal(INITIAL_STATE.length);
+            expect(newState.find(m => m.name === ACTION_ERROR_MASTER_DATA.name))
+                .to.deep.equal(updateItem);
+          });
+        });
+    });
+
+
 });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,5 @@
-import {combineReducers} from 'redux';
 import formsReducer from './form';
+import masterDataReducer from './master-data';
 
 export const forms = formsReducer;
+export const masterData = masterDataReducer;

--- a/src/reducers/master-data.js
+++ b/src/reducers/master-data.js
@@ -1,0 +1,29 @@
+import {REQUEST_MASTER_DATA, RESPONSE_MASTER_DATA, ERROR_MASTER_DATA} from '../actions/master-data';
+
+const _updateOrCreateMasterDataWithElement = (list = [], name, newValue) => {
+    const masterDataIdx = list.findIndex(d => d.name === name);
+    if(masterDataIdx !== -1) {
+      return [...list.slice(0, masterDataIdx), newValue ,...list.slice(masterDataIdx+1)];
+    } else {
+        return [...list, newValue];
+    }
+}
+
+const masterDataReducer = (state = [], action = {}) => {
+    //return state;
+    const {type} = action;
+    switch (type) {
+        case REQUEST_MASTER_DATA:
+          const loadingMasterData = {name: action.name, value: action.value, isLoading: true};
+          return _updateOrCreateMasterDataWithElement(state, action.name, loadingMasterData);
+        case RESPONSE_MASTER_DATA:
+          const responseMasterData = {name: action.name, value: action.value, isLoading: false};
+          return _updateOrCreateMasterDataWithElement(state, action.name, responseMasterData);
+        case ERROR_MASTER_DATA:
+          const errorMasterData = {name: action.name, error: action.error, isLoading: false};
+          return _updateOrCreateMasterDataWithElement(state, action.name, errorMasterData);
+        default:
+          return state;
+    }
+};
+export default masterDataReducer;

--- a/src/reducers/master-data.js
+++ b/src/reducers/master-data.js
@@ -14,13 +14,13 @@ const masterDataReducer = (state = [], action = {}) => {
     const {type} = action;
     switch (type) {
         case REQUEST_MASTER_DATA:
-          const loadingMasterData = {name: action.name, value: action.value, isLoading: true};
+          const loadingMasterData = {name: action.name, value: action.value, loading: true};
           return _updateOrCreateMasterDataWithElement(state, action.name, loadingMasterData);
         case RESPONSE_MASTER_DATA:
-          const responseMasterData = {name: action.name, value: action.value, isLoading: false};
+          const responseMasterData = {name: action.name, value: action.value, loading: false};
           return _updateOrCreateMasterDataWithElement(state, action.name, responseMasterData);
         case ERROR_MASTER_DATA:
-          const errorMasterData = {name: action.name, error: action.error, isLoading: false};
+          const errorMasterData = {name: action.name, error: action.error, loading: false};
           return _updateOrCreateMasterDataWithElement(state, action.name, errorMasterData);
         default:
           return state;


### PR DESCRIPTION
## master data 

- [x] Add behaviour to set the master data config: `MasterDataProvider`, the provider put in the context the array which is named `masterDataLoaders`, you have to pass to the provider the following configuration: `configuration = [{name, service, cacheDuration}]` which will be passed in the `masterDataLoaders`
- [x] Add behaviour to set the master data config: `connectMasterData` Connect the component to the load method of the master data. You have to pass an array of names in which you are interested. These names should correspond to the configuration you provide to the `MasterDataProvider`.
- [x] Add an action to load a masterData: `loadMasterData = (name, service, cacheDuration)`
- [x] Add a reducer to set a node in the redux state under the the name `masterData`