### PR TITLE
Feature example multiple entities

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -11,11 +11,16 @@ let entityJSON = [{
   lastName: 'De Libercourt'
 }];//require('./api-mock/notifs.json');
 
+let adressJSON = [{
+    uuid: '1234',
+    city: faker.address.city()
+  }
+];
 function createEntity(){
   return        {
           uuid: faker.random.uuid(),
           firstName: faker.name.firstName(),
-          lastName: faker.name.lastName()
+          lastName: faker.name.lastName(),
         };
 
 }
@@ -63,6 +68,14 @@ app.get(API_ROOT  + '/entity', function getAllNotifications(req, res) {
 
 app.get(API_ROOT  + '/entity/:id', function getSingleEntity(req, res) {
     res.json(entityJSON.find(d => d.uuid === req.params.id));
+  }
+);
+
+app.get(API_ROOT  + '/mixed/:id', function getSingleEntity(req, res) {
+    res.json({
+      user: entityJSON.find(d => d.uuid === req.params.id),
+      address: adressJSON.find(d => d.uuid = req.params.id)
+    });
   }
 );
 

--- a/src/behaviours/field.js
+++ b/src/behaviours/field.js
@@ -18,6 +18,8 @@ const fieldForBuilder = props => (propertyName, {FieldComponent = DefaultFieldCo
     const {fields, definitions, domains, onInputChange, onInputBlur, entityPathArray, editing} = props;
 
     // Check if the form has multiple entityPath. If it's the case, then check if an entityPath for the field is provided
+    // todo: souldn't it check if the property exists in both entity path from the array and throw an error if it is so.
+    // Maybe the cost is too high.
     if (entityPathArray.length > 1 && !entityPath) throw new Error(`You must provide an entityPath when calling fieldFor('${propertyName}') since the form has multiple entityPath ${entityPathArray}`);
     entityPath = entityPath ? entityPath : entityPathArray[0];
 

--- a/src/example/actions/user-actions.js
+++ b/src/example/actions/user-actions.js
@@ -1,9 +1,14 @@
 import {actionBuilder} from '../../actions/entity-actions-builder';
-import {loadUserSvc, saveUserSvc} from '../services/user-service';
+import {loadUserSvc, saveUserSvc, loadMixedEntities} from '../services/user-service';
 
 const loadAction = actionBuilder({names: ['user'], type: 'load', service: loadUserSvc});
 export const loadUserTypes = loadAction.types;
 export const loadUserAction = loadAction.action;
+
+const _loadMixedAction = actionBuilder({names: ['user', 'address'], type: 'load', service: loadMixedEntities});
+export const loadMixedTypes = _loadMixedAction.types;
+export const loadMixedAction = _loadMixedAction.action;
+
 
 const saveAction = actionBuilder({names: ['user'], type: 'save', service: saveUserSvc});
 export const saveUserTypes = saveAction.types;

--- a/src/example/components/user-and-address-dumb.js
+++ b/src/example/components/user-and-address-dumb.js
@@ -1,0 +1,59 @@
+import React, {Component, PropTypes} from 'react';
+import {connect as connectToForm } from '../../behaviours/form';
+import {connect as connectToMetadata} from '../../behaviours/metadata';
+import {connect as connectToFieldHelpers} from '../../behaviours/field';
+import {connect as connectToMasterData} from '../../behaviours/master-data';
+import {loadMixedAction, saveUserAction} from '../actions/user-actions';
+
+// Dumb components
+import Field from '../../components/field';
+import Button from './button';
+import compose from 'lodash/flowRight';
+
+function UserDumbComponent({fields, fieldFor, load, save, id, getUserInput, toggleEdit, editing, loadMasterData, ...otherProps}) {
+    const renderEditingButtons = () => (
+        <div>
+            <Button onClick={() => toggleEdit(false)}>Cancel</Button>
+            <Button onClick={() => save(getUserInput())}>{'Save'}</Button>
+        </div>
+    );
+    const renderConsultingButton = () => (
+        <Button onClick={() => toggleEdit(true)}>Edit</Button>
+    );
+    return (
+        <div>
+            {editing && renderEditingButtons()}
+            {!editing && renderConsultingButton()}
+            {/* Fields auto rendering to test direct rendering without helpers*/}
+            <Button onClick={() => {load({id})}}>Load entity from server</Button>
+            {/* Load both address and user.  */}
+            <Button onClick={() => loadMasterData()}>Load master data</Button>
+            {/* I shouldn't have to specify the entityPath it could be done automatically*/}
+            {fieldFor('uuid', {onChange: () => {console.log(fields)}, entityPath: 'user'})}
+            {fieldFor('firstName', {entityPath: 'user'})}
+            {fieldFor('lastName', {entityPath: 'user'})}
+            {fieldFor('date', {entityPath: 'user'})}
+            {fieldFor('city', {entityPath: 'address'})}
+        </div>
+    );
+}
+
+UserDumbComponent.displayName = UserDumbComponent;
+
+const formConfig = {
+    formKey: 'userForm',
+    entityPathArray: ['user', 'address'],
+    loadAction: loadMixedAction,
+    saveAction: saveUserAction,
+    nonValidatedFields: ['user.firstName']
+};
+
+//Connect the component to all its behaviours (respect the order for store, store -> props, helper)
+const ConnectedUserDumbComponent = compose(
+    connectToMetadata(['user', 'address']),
+    connectToMasterData(['civility']),
+    connectToForm(formConfig),
+    connectToFieldHelpers()
+)(UserDumbComponent);
+
+export default ConnectedUserDumbComponent;

--- a/src/example/components/user-and-address-dumb.js
+++ b/src/example/components/user-and-address-dumb.js
@@ -41,7 +41,8 @@ function UserDumbComponent({fields, fieldFor, load, save, id, getUserInput, togg
 UserDumbComponent.displayName = UserDumbComponent;
 
 const formConfig = {
-    formKey: 'userForm',
+    //todo: it should raise an error if i use the same formKey.
+    formKey: 'userAndAddressForm',
     entityPathArray: ['user', 'address'],
     loadAction: loadMixedAction,
     saveAction: saveUserAction,

--- a/src/example/index.js
+++ b/src/example/index.js
@@ -11,6 +11,7 @@ import {Provider as MetadataProvider} from '../behaviours/metadata';
 import {Provider as FieldHelpersProvider} from '../behaviours/field';
 import {Provider as MasterDataProvider} from '../behaviours/master-data';
 import UserDumbComponent from './components/user-dumb';
+import UserAndAddressDumbComponent from './components/user-and-address-dumb';
 import InputComponent from '../components/input';
 import DevTools from './containers/dev-tools';
 import {loadCivility} from './services/load-civility';
@@ -25,6 +26,10 @@ const definitions = {
         firstName: { domain: 'DO_RODRIGO', isRequired: false},
         lastName: { domain: 'DO_DON_DIEGO', isRequired: true},
         date: { domain: 'DO_DATE', isRequired: false}
+    },
+    address: {
+        uuid: { domain: 'DO_RODRIGO', isRequired: false},
+        city: { domain: 'DO_DON_DIEGO', isRequired: true}
     }
 }
 
@@ -67,6 +72,8 @@ const App = () => {
                             <div>
                                 <h1>User Dumb</h1>
                                 <UserDumbComponent id={1234} />
+                              <h1>User and address Dumb</h1>
+                              <UserAndAddressDumbComponent id={1234}/>
                             </div>
                         </FieldHelpersProvider>
                     </div>

--- a/src/example/reducers/address-reducers.js
+++ b/src/example/reducers/address-reducers.js
@@ -1,0 +1,24 @@
+import {reducerBuilder} from '../../reducers/reducer-builder';
+import {loadMixedTypes} from '../actions/user-actions';
+
+//types to use
+// question here is should loadUserTypes be more like {request, receive} instead of {REQUEST_LOAD_USER, RESPONSE_LOAD_USER}
+// I prefer the things as they are now but I would like your opinion @BernardStanislas and @Tommass
+const {REQUEST_LOAD_ADDRESS, RESPONSE_LOAD_ADDRESS, ERROR_LOAD_ADDRESS} = loadMixedTypes;
+
+// default data
+const DEFAULT_DATA = {
+    city: 'Libercourt'
+};
+
+// Reducer for the user entity with a state modification on load and save.
+const userReducer = reducerBuilder({
+    types: {
+        load: {request: REQUEST_LOAD_ADDRESS, response: RESPONSE_LOAD_ADDRESS, error: ERROR_LOAD_ADDRESS},
+        //todo: this is an error i need a save but i shouldn't
+        save: {request: REQUEST_LOAD_ADDRESS, response: RESPONSE_LOAD_ADDRESS, error: ERROR_LOAD_ADDRESS}
+    },
+    defaultData: DEFAULT_DATA
+});
+
+export default userReducer;

--- a/src/example/reducers/index.js
+++ b/src/example/reducers/index.js
@@ -1,7 +1,9 @@
 import {combineReducers} from 'redux';
 import userReducer from './user-reducer';
+import addressReducer from './address-reducers';
 
 // export a root reducer
 export default combineReducers({
-    user: userReducer
+    user: userReducer,
+    address: addressReducer
 });

--- a/src/example/services/user-service.js
+++ b/src/example/services/user-service.js
@@ -4,6 +4,12 @@ export const loadUserSvc = async ({id}) => {
     return data;
 }
 
+export const loadMixedEntities =  async({id}) => {
+  const response = await fetch(`http://localhost:9999/x/mixed/${id}`);
+  const data = await response.json();
+  return data;
+}
+
 export const saveUserSvc = async (user) => {
     // const response = await fetch(`http://localhost:9999/x/entity/${user.id}`)
     // const data = await response.json();


### PR DESCRIPTION
## What's inside

- [x] API add a mixed route
- [x] Example: add a mixed entities with addres and user
- [x] Example: add  an action which load both address and user
- [x] Example: add  a reducer for the address

## problems

- [ ] When I have two component with the same `formKey` there is no warning or error
- [ ] When I have two entities with two definitions i must specify the `entityPath` in the `fieldFor`
- [ ] The reducer builder needs a save parameter, it should not
 
> This problems should be fixed in other PR, the goal of this one was to have an explicit example.
